### PR TITLE
Removed space between the 3rd and 4th tabs on line 206

### DIFF
--- a/addons/newgrounds/NewGroundsAPI.gd
+++ b/addons/newgrounds/NewGroundsAPI.gd
@@ -203,7 +203,7 @@ class ComponentScoreBoard:
 		api._call_ng_api(NAME, 'getScores', sessionId,
 			{
 				'id' : scoreId, 'limit': limit, 'skip': skip, 'social': social, 'tag': tag,
-			 	'period': period, 'userId': userId
+				'period': period, 'userId': userId
 			})
 		pass
 


### PR DESCRIPTION
Removed space between the 3rd and 4th tabs on line 206 that would cause the addon to not compile in godot 3.2.2